### PR TITLE
Add rspec/matchers require to readme test_helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ subclass `ActiveSupport::TestCase` instead of `MiniTest::Spec.`
 ```ruby
 # test/test_helper.rb
 require "capybara/rails"
+require "capybara/rspec/matchers"
 
 class AcceptanceTest < MiniTest::Spec
   include Capybara::RSpecMatchers


### PR DESCRIPTION
capybara/rails no longer includes RSpecMatchers*, so including as described in
the README previously failed as it was an unknown constant.

This commit requires it, so that it will no longer throw an error if you follow
the README instructions.
- See https://github.com/jnicklas/capybara/blob/master/lib/capybara/rails.rb
