### PR TITLE
Create assertions and expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require "capybara/rails"
 # for just minitest/unit
 class AcceptanceTest < Minitest::Unit::TestCase
   include Capybara::DSL
-  include Minitest::Capybara::Assertions
+  include Capybara::Assertions
 
   def teardown
     Capybara.reset_session!

--- a/lib/capybara/assertions.rb
+++ b/lib/capybara/assertions.rb
@@ -1,0 +1,295 @@
+require "minitest/capybara"
+
+module Capybara
+  module Assertions
+    def self.included(base)
+      raise "Make sure to include Capybara::Minitest::Assertions after Capybara::DSL" unless base < Capybara::DSL
+    end
+
+    def assert_text(*args)
+      node, *args = prepare_args(args)
+      assert has_text?(*args), message { "Expected to include #{args.first.inspect}" }
+    end
+    alias_method :assert_content, :assert_text
+
+    def refute_text(*args)
+      node, *args = prepare_args(args)
+      assert has_no_text?(*args), message { "Expected not to include #{args.first.inspect}" }
+    end
+    alias_method :assert_no_text, :refute_text
+    alias_method :refute_content, :refute_text
+    alias_method :assert_no_content, :refute_text
+
+    def assert_selector(*args)
+      node, *args = prepare_args(args)
+      node.assert_selector(*args)
+    rescue Capybara::ExpectationNotMet => e
+      assert false, e.message
+    end
+
+    def refute_selector(*args)
+      node, *args = prepare_args(args)
+      node.assert_no_selector(*args)
+    rescue Capybara::ExpectationNotMet => e
+      assert false, e.message
+    end
+    alias_method :assert_no_selector, :refute_selector
+
+    ruby = ""
+    (Minitest::Capybara.assertions - %w[text content selector]).each do |assertion|
+      ruby << <<-RUBY
+        def assert_#{assertion}(*args)
+          node, *args = prepare_args(args)
+          assert node.has_#{assertion}?(*args), message { Capybara::Helpers.failure_message(*args) }
+        end
+      RUBY
+    end
+    (Minitest::Capybara.refutations - %w[text content selector]).each do |refutation|
+      ruby << <<-RUBY
+        def refute_#{refutation}(*args)
+          node, *args = prepare_args(args)
+          assert node.has_no_#{refutation}?(*args), message { Capybara::Helpers.failure_message(*args) }
+        end
+        alias_method :assert_no_#{refutation}, :refute_#{refutation}
+      RUBY
+    end
+    class_eval(ruby)
+
+    ##
+    # Assertion that there is button
+    #
+    # see Capybara::Assertions#refute_button
+    # see Capybara::Assertions#assert_no_button
+    # see Capybara::expectations#must_have_button
+    # see Capybara::expectations#wont_have_button
+    # :method: assert_button
+
+    ##
+    # Assertion that there is no button
+    #
+    # see Capybara::Assertions#assert_button
+    # see Capybara::expectations#must_have_button
+    # see Capybara::expectations#wont_have_button
+    # :method: refute_button
+    # :alias: assert_no_button
+
+
+    ##
+    # Assertion that there is checked_field
+    #
+    # see Capybara::Assertions#refute_checked_field
+    # see Capybara::Assertions#assert_no_checked_field
+    # see Capybara::expectations#must_have_checked_field
+    # see Capybara::expectations#wont_have_checked_field
+    # :method: assert_checked_field
+
+    ##
+    # Assertion that there is no checked_field
+    #
+    # see Capybara::Assertions#assert_checked_field
+    # see Capybara::expectations#must_have_checked_field
+    # see Capybara::expectations#wont_have_checked_field
+    # :method: refute_checked_field
+    # :alias: assert_no_checked_field
+
+
+    ##
+    # Assertion that there is content
+    #
+    # see Capybara::Assertions#refute_content
+    # see Capybara::Assertions#assert_no_content
+    # see Capybara::expectations#must_have_content
+    # see Capybara::expectations#wont_have_content
+    # :method: assert_content
+
+    ##
+    # Assertion that there is no content
+    #
+    # see Capybara::Assertions#assert_content
+    # see Capybara::expectations#must_have_content
+    # see Capybara::expectations#wont_have_content
+    # :method: refute_content
+    # :alias: assert_no_content
+
+
+    ##
+    # Assertion that there is css
+    #
+    # see Capybara::Assertions#refute_css
+    # see Capybara::Assertions#assert_no_css
+    # see Capybara::expectations#must_have_css
+    # see Capybara::expectations#wont_have_css
+    # :method: assert_css
+
+    ##
+    # Assertion that there is no css
+    #
+    # see Capybara::Assertions#assert_css
+    # see Capybara::expectations#must_have_css
+    # see Capybara::expectations#wont_have_css
+    # :method: refute_css
+    # :alias: assert_no_css
+
+
+    ##
+    # Assertion that there is field
+    #
+    # see Capybara::Assertions#refute_field
+    # see Capybara::Assertions#assert_no_field
+    # see Capybara::expectations#must_have_field
+    # see Capybara::expectations#wont_have_field
+    # :method: assert_field
+
+    ##
+    # Assertion that there is no field
+    #
+    # see Capybara::Assertions#assert_field
+    # see Capybara::expectations#must_have_field
+    # see Capybara::expectations#wont_have_field
+    # :method: refute_field
+    # :alias: assert_no_field
+
+
+    ##
+    # Assertion that there is link
+    #
+    # see Capybara::Assertions#refute_link
+    # see Capybara::Assertions#assert_no_link
+    # see Capybara::expectations#must_have_link
+    # see Capybara::expectations#wont_have_link
+    # :method: assert_link
+
+    ##
+    # Assertion that there is no link
+    #
+    # see Capybara::Assertions#assert_link
+    # see Capybara::expectations#must_have_link
+    # see Capybara::expectations#wont_have_link
+    # :method: refute_link
+    # :alias: assert_no_link
+
+
+    ##
+    # Assertion that there is select
+    #
+    # see Capybara::Assertions#refute_select
+    # see Capybara::Assertions#assert_no_select
+    # see Capybara::expectations#must_have_select
+    # see Capybara::expectations#wont_have_select
+    # :method: assert_select
+
+    ##
+    # Assertion that there is no select
+    #
+    # see Capybara::Assertions#assert_select
+    # see Capybara::expectations#must_have_select
+    # see Capybara::expectations#wont_have_select
+    # :method: refute_select
+    # :alias: assert_no_select
+
+
+    ##
+    # Assertion that there is selector
+    #
+    # see Capybara::Assertions#refute_selector
+    # see Capybara::Assertions#assert_no_selector
+    # see Capybara::expectations#must_have_selector
+    # see Capybara::expectations#wont_have_selector
+    # :method: assert_selector
+
+    ##
+    # Assertion that there is no selector
+    #
+    # see Capybara::Assertions#assert_selector
+    # see Capybara::expectations#must_have_selector
+    # see Capybara::expectations#wont_have_selector
+    # :method: refute_selector
+    # :alias: assert_no_selector
+
+
+    ##
+    # Assertion that there is table
+    #
+    # see Capybara::Assertions#refute_table
+    # see Capybara::Assertions#assert_no_table
+    # see Capybara::expectations#must_have_table
+    # see Capybara::expectations#wont_have_table
+    # :method: assert_table
+
+    ##
+    # Assertion that there is no table
+    #
+    # see Capybara::Assertions#assert_table
+    # see Capybara::expectations#must_have_table
+    # see Capybara::expectations#wont_have_table
+    # :method: refute_table
+    # :alias: assert_no_table
+
+
+    ##
+    # Assertion that there is text
+    #
+    # see Capybara::Assertions#refute_text
+    # see Capybara::Assertions#assert_no_text
+    # see Capybara::expectations#must_have_text
+    # see Capybara::expectations#wont_have_text
+    # :method: assert_text
+
+    ##
+    # Assertion that there is no text
+    #
+    # see Capybara::Assertions#assert_text
+    # see Capybara::expectations#must_have_text
+    # see Capybara::expectations#wont_have_text
+    # :method: refute_text
+    # :alias: assert_no_text
+
+
+    ##
+    # Assertion that there is unchecked_field
+    #
+    # see Capybara::Assertions#refute_unchecked_field
+    # see Capybara::Assertions#assert_no_unchecked_field
+    # see Capybara::expectations#must_have_unchecked_field
+    # see Capybara::expectations#wont_have_unchecked_field
+    # :method: assert_unchecked_field
+
+    ##
+    # Assertion that there is no unchecked_field
+    #
+    # see Capybara::Assertions#assert_unchecked_field
+    # see Capybara::expectations#must_have_unchecked_field
+    # see Capybara::expectations#wont_have_unchecked_field
+    # :method: refute_unchecked_field
+    # :alias: assert_no_unchecked_field
+
+
+    ##
+    # Assertion that there is xpath
+    #
+    # see Capybara::Assertions#refute_xpath
+    # see Capybara::Assertions#assert_no_xpath
+    # see Capybara::expectations#must_have_xpath
+    # see Capybara::expectations#wont_have_xpath
+    # :method: assert_xpath
+
+    ##
+    # Assertion that there is no xpath
+    #
+    # see Capybara::Assertions#assert_xpath
+    # see Capybara::expectations#must_have_xpath
+    # see Capybara::expectations#wont_have_xpath
+    # :method: refute_xpath
+    # :alias: assert_no_xpath
+
+    private
+
+    def prepare_args(args)
+      if args.first.is_a?(Capybara::Session) || args.first.kind_of?(Capybara::Node::Base)
+        args
+      else
+        [page, *args]
+      end
+    end
+  end
+end

--- a/lib/capybara/expectations.rb
+++ b/lib/capybara/expectations.rb
@@ -1,0 +1,248 @@
+require "minitest/capybara"
+require "minitest/spec"
+
+module Capybara
+  module Expectations
+    Minitest::Capybara.assertions.each do |assertion|
+      infect_an_assertion "assert_#{assertion}", "must_have_#{assertion}", :reverse
+    end
+    Minitest::Capybara.refutations.each do |refutation|
+      infect_an_assertion "refute_#{refutation}", "wont_have_#{refutation}", :reverse
+    end
+
+    ##
+    # Expectation that there is button
+    #
+    # see Capybara::Expectations#wont_have_button
+    # see Capybara::Assertions#assert_button
+    # see Capybara::Assertions#refute_button
+    # see Capybara::Assertions#assert_no_button
+    # :method: must_have_button
+
+    ##
+    # Expectation that there is no button
+    #
+    # see Capybara::Expectations#must_have_button
+    # see Capybara::Assertions#assert_button
+    # see Capybara::Assertions#refute_button
+    # see Capybara::Assertions#assert_no_button
+    # :method: wont_have_button
+
+
+    ##
+    # Expectation that there is checked_field
+    #
+    # see Capybara::Expectations#wont_have_checked_field
+    # see Capybara::Assertions#assert_checked_field
+    # see Capybara::Assertions#refute_checked_field
+    # see Capybara::Assertions#assert_no_checked_field
+    # :method: must_have_checked_field
+
+    ##
+    # Expectation that there is no checked_field
+    #
+    # see Capybara::Expectations#must_have_checked_field
+    # see Capybara::Assertions#assert_checked_field
+    # see Capybara::Assertions#refute_checked_field
+    # see Capybara::Assertions#assert_no_checked_field
+    # :method: wont_have_checked_field
+
+
+    ##
+    # Expectation that there is content
+    #
+    # see Capybara::Expectations#wont_have_content
+    # see Capybara::Assertions#assert_content
+    # see Capybara::Assertions#refute_content
+    # see Capybara::Assertions#assert_no_content
+    # :method: must_have_content
+
+    ##
+    # Expectation that there is no content
+    #
+    # see Capybara::Expectations#must_have_content
+    # see Capybara::Assertions#assert_content
+    # see Capybara::Assertions#refute_content
+    # see Capybara::Assertions#assert_no_content
+    # :method: wont_have_content
+
+
+    ##
+    # Expectation that there is css
+    #
+    # see Capybara::Expectations#wont_have_css
+    # see Capybara::Assertions#assert_css
+    # see Capybara::Assertions#refute_css
+    # see Capybara::Assertions#assert_no_css
+    # :method: must_have_css
+
+    ##
+    # Expectation that there is no css
+    #
+    # see Capybara::Expectations#must_have_css
+    # see Capybara::Assertions#assert_css
+    # see Capybara::Assertions#refute_css
+    # see Capybara::Assertions#assert_no_css
+    # :method: wont_have_css
+
+
+    ##
+    # Expectation that there is field
+    #
+    # see Capybara::Expectations#wont_have_field
+    # see Capybara::Assertions#assert_field
+    # see Capybara::Assertions#refute_field
+    # see Capybara::Assertions#assert_no_field
+    # :method: must_have_field
+
+    ##
+    # Expectation that there is no field
+    #
+    # see Capybara::Expectations#must_have_field
+    # see Capybara::Assertions#assert_field
+    # see Capybara::Assertions#refute_field
+    # see Capybara::Assertions#assert_no_field
+    # :method: wont_have_field
+
+
+    ##
+    # Expectation that there is link
+    #
+    # see Capybara::Expectations#wont_have_link
+    # see Capybara::Assertions#assert_link
+    # see Capybara::Assertions#refute_link
+    # see Capybara::Assertions#assert_no_link
+    # :method: must_have_link
+
+    ##
+    # Expectation that there is no link
+    #
+    # see Capybara::Expectations#must_have_link
+    # see Capybara::Assertions#assert_link
+    # see Capybara::Assertions#refute_link
+    # see Capybara::Assertions#assert_no_link
+    # :method: wont_have_link
+
+
+    ##
+    # Expectation that there is select
+    #
+    # see Capybara::Expectations#wont_have_select
+    # see Capybara::Assertions#assert_select
+    # see Capybara::Assertions#refute_select
+    # see Capybara::Assertions#assert_no_select
+    # :method: must_have_select
+
+    ##
+    # Expectation that there is no select
+    #
+    # see Capybara::Expectations#must_have_select
+    # see Capybara::Assertions#assert_select
+    # see Capybara::Assertions#refute_select
+    # see Capybara::Assertions#assert_no_select
+    # :method: wont_have_select
+
+
+    ##
+    # Expectation that there is selector
+    #
+    # see Capybara::Expectations#wont_have_selector
+    # see Capybara::Assertions#assert_selector
+    # see Capybara::Assertions#refute_selector
+    # see Capybara::Assertions#assert_no_selector
+    # :method: must_have_selector
+
+    ##
+    # Expectation that there is no selector
+    #
+    # see Capybara::Expectations#must_have_selector
+    # see Capybara::Assertions#assert_selector
+    # see Capybara::Assertions#refute_selector
+    # see Capybara::Assertions#assert_no_selector
+    # :method: wont_have_selector
+
+
+    ##
+    # Expectation that there is table
+    #
+    # see Capybara::Expectations#wont_have_table
+    # see Capybara::Assertions#assert_table
+    # see Capybara::Assertions#refute_table
+    # see Capybara::Assertions#assert_no_table
+    # :method: must_have_table
+
+    ##
+    # Expectation that there is no table
+    #
+    # see Capybara::Expectations#must_have_table
+    # see Capybara::Assertions#assert_table
+    # see Capybara::Assertions#refute_table
+    # see Capybara::Assertions#assert_no_table
+    # :method: wont_have_table
+
+
+    ##
+    # Expectation that there is text
+    #
+    # see Capybara::Expectations#wont_have_text
+    # see Capybara::Assertions#assert_text
+    # see Capybara::Assertions#refute_text
+    # see Capybara::Assertions#assert_no_text
+    # :method: must_have_text
+
+    ##
+    # Expectation that there is no text
+    #
+    # see Capybara::Expectations#must_have_text
+    # see Capybara::Assertions#assert_text
+    # see Capybara::Assertions#refute_text
+    # see Capybara::Assertions#assert_no_text
+    # :method: wont_have_text
+
+
+    ##
+    # Expectation that there is unchecked_field
+    #
+    # see Capybara::Expectations#wont_have_unchecked_field
+    # see Capybara::Assertions#assert_unchecked_field
+    # see Capybara::Assertions#refute_unchecked_field
+    # see Capybara::Assertions#assert_no_unchecked_field
+    # :method: must_have_unchecked_field
+
+    ##
+    # Expectation that there is no unchecked_field
+    #
+    # see Capybara::Expectations#must_have_unchecked_field
+    # see Capybara::Assertions#assert_unchecked_field
+    # see Capybara::Assertions#refute_unchecked_field
+    # see Capybara::Assertions#assert_no_unchecked_field
+    # :method: wont_have_unchecked_field
+
+
+    ##
+    # Expectation that there is xpath
+    #
+    # see Capybara::Expectations#wont_have_xpath
+    # see Capybara::Assertions#assert_xpath
+    # see Capybara::Assertions#refute_xpath
+    # see Capybara::Assertions#assert_no_xpath
+    # :method: must_have_xpath
+
+    ##
+    # Expectation that there is no xpath
+    #
+    # see Capybara::Expectations#must_have_xpath
+    # see Capybara::Assertions#assert_xpath
+    # see Capybara::Assertions#refute_xpath
+    # see Capybara::Assertions#assert_no_xpath
+    # :method: wont_have_xpath
+  end
+end
+
+class Capybara::Session
+  include Capybara::Expectations unless ENV["MT_NO_EXPECTATIONS"]
+end
+
+class Capybara::Node::Base
+  include Capybara::Expectations unless ENV["MT_NO_EXPECTATIONS"]
+end

--- a/lib/minitest/capybara.rb
+++ b/lib/minitest/capybara.rb
@@ -1,83 +1,35 @@
-require 'minitest/capybara/version'
-require 'minitest/spec'
+require "minitest/capybara/version"
+require "capybara"
 
-module Minitest::Capybara
-  module Assertions
-    METHODS = Capybara::Session::NODE_METHODS.grep(/^has_/).map { |s| s.to_s.match(/has_(.*?)\?/)[1] }
-
-    def self.included(base)
-      raise "Make sure to include Capybara::Minitest::Assertions after Capybara::DSL" unless base < Capybara::DSL
+module Minitest
+  module Capybara
+    @@assertions = ::Capybara::Session::NODE_METHODS.grep(/^has_/).map { |s| s.to_s.match(/^has_(.*?)\?/)[1] }
+    @@refutations = @@assertions.grep(/^no_/)
+    @@assertions = (@@assertions - @@refutations).sort
+    @@refutations = @@refutations.map { |s| s.match(/^no_(.*)/)[1] }.sort
+    def self.assertions
+      @@assertions
     end
-
-    def self.assertion_name(method)
-      method.start_with?('no_') ? "refute_#{method.gsub(/^no_/, '')}" : "assert_#{method}"
+    def self.refutations
+      @@refutations
     end
+  end
+end
 
-    def assert_text(*args)
-      node, *args = prepare_args(args)
-      assert has_text?(*args), message { "Expected to include #{args.first.inspect}" }
-    end
-    alias_method :assert_content, :assert_text
+# Need to be required after Minitest::Capybara is defined
+require "capybara/assertions"
+require "capybara/expectations"
 
-    def refute_text(*args)
-      node, *args = prepare_args(args)
-      assert has_no_text?(*args), message { "Expected not to include #{args.first.inspect}" }
-    end
-    alias_method :refute_content, :refute_text
-
-    def assert_selector(*args)
-      node, *args = prepare_args(args)
-      node.assert_selector(*args)
-    rescue Capybara::ExpectationNotMet => e
-      assert false, e.message
-    end
-
-    def refute_selector(*args)
-      node, *args = prepare_args(args)
-      node.assert_no_selector(*args)
-    rescue Capybara::ExpectationNotMet => e
-      assert false, e.message
-    end
-
-    ruby = ""
-    (METHODS - %w[text no_text content no_content selector no_selector]).each do |method|
-      assertion_name = method.start_with?('no') ? "refute_#{method.gsub(/^no_/, '')}" : "assert_#{method}"
-
-      ruby << <<-RUBY
-        def #{assertion_name}(*args)
-          node, *args = prepare_args(args)
-          assert node.has_#{method}?(*args), message { Capybara::Helpers.failure_message(*args) }
-        end
-      RUBY
-    end
-    class_eval(ruby)
-
-    private
-
-    def prepare_args(args)
-      if args.first.is_a?(Capybara::Session) || args.first.kind_of?(Capybara::Node::Base)
-        args
+# :stopdoc:
+module Minitest
+  module Capybara
+    def self.const_missing const
+      if :Assertions == const
+        warn "Minitest::Capybara::Assertions is deprecated. Please use Capybara::Assertions instead."
+        ::Capybara::Assertions
       else
-        [page, *args]
+        super const
       end
     end
   end
-
-  module Expectations
-    def self.expectation_name(method)
-      method.start_with?('no_') ? "wont_have_#{method.gsub(/^no_/, '')}" : "must_have_#{method}"
-    end
-
-    Assertions::METHODS.each do |method|
-      infect_an_assertion Assertions.assertion_name(method), expectation_name(method), :reverse
-    end
-  end
-end
-
-class Capybara::Session
-  include Minitest::Capybara::Expectations
-end
-
-class Capybara::Node::Base
-  include Minitest::Capybara::Expectations
 end

--- a/test/capybara/assertions_test.rb
+++ b/test/capybara/assertions_test.rb
@@ -1,0 +1,36 @@
+require "minitest/autorun"
+
+require "capybara"
+require "minitest/capybara"
+
+Capybara.app = lambda { |env| [200, {}, "<div><h1>foo</h1><a href='/'>bar</a></div>"] }
+
+describe "Assertions" do
+  include Capybara::DSL
+  include Capybara::Assertions
+
+  before do
+    visit "/"
+  end
+
+  it "defines all the assertions that Capybara does" do
+    Minitest::Capybara.assertions.each do |assertion|
+      assert self.respond_to?("assert_#{assertion}"),
+             "The assertion assert_#{assertion} is not defined."
+    end
+  end
+
+  it "defines all the refutations that Capybara does" do
+    Minitest::Capybara.refutations.each do |refutation|
+      assert self.respond_to?("refute_#{refutation}"),
+             "The assertion refute_#{refutation} is not defined."
+    end
+  end
+
+  it "defines all the negative assertions that Capybara does" do
+    Minitest::Capybara.refutations.each do |refutation|
+      assert self.respond_to?("assert_no_#{refutation}"),
+             "The assertion assert_no_#{refutation} is not defined."
+    end
+  end
+end

--- a/test/capybara/expectations_test.rb
+++ b/test/capybara/expectations_test.rb
@@ -1,0 +1,29 @@
+require "minitest/autorun"
+
+require "capybara"
+require "minitest/capybara"
+
+Capybara.app = lambda { |env| [200, {}, "<div><h1>foo</h1><a href='/'>bar</a></div>"] }
+
+describe "Expectations" do
+  include Capybara::DSL
+  include Capybara::Assertions
+
+  before do
+    visit "/"
+  end
+
+  it "defines all the must expectations that Capybara does" do
+    Minitest::Capybara.assertions.each do |assertion|
+      assert page.respond_to?("must_have_#{assertion}"),
+             "The expectation must_have_#{assertion} is not defined."
+    end
+  end
+
+  it "defines all the wont expectations that Capybara does" do
+    Minitest::Capybara.refutations.each do |refutation|
+      assert page.respond_to?("wont_have_#{refutation}"),
+             "The expectation wont_have_#{refutation} is not defined."
+    end
+  end
+end


### PR DESCRIPTION
This is an alternate take on adding the functionality found in [pull request 2](https://github.com/wojtekmach/minitest-capybara/pull/2).

Moves the assertions and expectations modules into the Capybara namespace. Adds some extra test coverage. Etc...
