### PR TITLE
fixed content assertions and expectations for non-page Capybara::Nodes

### DIFF
--- a/lib/capybara/assertions.rb
+++ b/lib/capybara/assertions.rb
@@ -6,13 +6,13 @@ module Capybara
 
     def assert_text(*args)
       node, *args = prepare_args(args)
-      assert has_text?(*args), message { "Expected to include #{args.first.inspect}" }
+      assert node.has_text?(*args), message { "Expected to include #{args.first.inspect}" }
     end
     alias_method :assert_content, :assert_text
 
     def refute_text(*args)
       node, *args = prepare_args(args)
-      assert has_no_text?(*args), message { "Expected not to include #{args.first.inspect}" }
+      assert node.has_no_text?(*args), message { "Expected not to include #{args.first.inspect}" }
     end
     alias_method :assert_no_text, :refute_text
     alias_method :refute_content, :refute_text
@@ -283,7 +283,8 @@ module Capybara
     private
 
     def prepare_args(args)
-      if args.first.is_a?(Capybara::Session) || args.first.kind_of?(Capybara::Node::Base)
+      if args.first.is_a?(Capybara::Session) || args.first.kind_of?(Capybara::Node::Base) ||
+          args.first.is_a?(Capybara::Node::Simple)
         args
       else
         [page, *args]

--- a/lib/capybara/expectations.rb
+++ b/lib/capybara/expectations.rb
@@ -246,3 +246,7 @@ end
 class Capybara::Node::Base
   include Capybara::Expectations unless ENV["MT_NO_EXPECTATIONS"]
 end
+
+class Capybara::Node::Simple
+  include Capybara::Expectations unless ENV["MT_NO_EXPECTATIONS"]
+end

--- a/test/minitest/base_node_test.rb
+++ b/test/minitest/base_node_test.rb
@@ -1,0 +1,58 @@
+require File.join(File.dirname(__FILE__), '..', 'test_helper')
+
+describe Capybara do
+  describe '.string' do
+    include Capybara::DSL
+    include Capybara::Assertions
+
+    before do
+      @test_node= Capybara.string <<-STRING
+        Hi everybody
+
+        I am a simple e-mail and just want to be tested
+
+        Greetings
+
+        Your friendly tester
+      STRING
+    end
+
+    describe "assertions" do
+      it "can assert_content String" do
+        assert_content @test_node, "everybody"
+      end
+
+      it "can assert_content Regexp" do
+        assert_content @test_node, /simple e-mail/
+        assert_content @test_node, /just.*tested/
+      end
+
+      it "wont match Regexp in a String" do
+        proc { assert_content(@test_node, "just.*tested") }.must_raise Minitest::Assertion
+      end
+
+      it "can refute_content" do
+        refute_content @test_node, "Everybody"
+      end
+    end
+
+    describe "expectations" do
+      it "supports must_have_content" do
+        @test_node.must_have_content "everybody"
+      end
+
+      it "supports must_have_content with regexp" do
+        @test_node.must_have_content /simple e-mail/
+        @test_node.must_have_content /just.*tested/
+      end
+
+      it "wont have Regexp content in a String" do
+        proc { @test_node.must_have_content "just.*tested" }.must_raise Minitest::Assertion
+      end
+
+      it "supports wont_have_content" do
+        @test_node.wont_have_content "Everybody"
+      end
+    end
+  end
+end


### PR DESCRIPTION
use the node found by prepare_args to actually match text
allow Capybara::Node::Simple as argument of Minitest asserts (as Capybara allows them so should Minitest)
add tests for text assertions
add tests for text expectations

I actually ran into this bug while after catching the latest version of `minitest-capybara` with a hasty `bundle update` after I upgraded to `rbenv`. The new version broke my e-mail tests which used `capybara-email`. During testing I discovered that Minitest assertions would not work for `Capybara::Node::Simple` so I added that too since it was in the same file.
