### PR TITLE
updating capybara to 2.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     minitest-capybara (0.7.0)
-      capybara (~> 2.2.0)
+      capybara (~> 2.3.0)
       minitest (~> 5.0)
       rake
 
 GEM
   remote: https://rubygems.org/
   specs:
-    capybara (2.2.0)
+    capybara (2.3.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)

--- a/minitest-capybara.gemspec
+++ b/minitest-capybara.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "capybara", "~> 2.2.0"
+  s.add_dependency "capybara", "~> 2.3.0"
 
   s.add_runtime_dependency "rake"
   s.add_runtime_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
sorry, but capybara 2.2 wasn't enough :disappointed_relieved:

```
Capybara::RSpecMatchers::HaveText implements a legacy RSpec matcher
protocol. For the current protocol you should expose the failure messages
via the `failure_message` and `failure_message_when_negated` methods.
(Used from /foo/spec/features/foo_spec.rb:16:in `block (2 levels) in <top (required)>')
```

if it's possible, it would be _awesome_ to release the next version as `0.7.1`, so minitest-rails-capybara guys doesn't need to release another version as well.

related:
- [x] https://github.com/jnicklas/capybara/pull/1219
- [x] https://github.com/blowmage/minitest-rails-capybara/pull/28
- [x] https://github.com/wojtekmach/minitest-capybara/pull/11
