### PR TITLE
Update exception message to Capybara::Assertions.

### DIFF
--- a/lib/capybara/assertions.rb
+++ b/lib/capybara/assertions.rb
@@ -1,7 +1,7 @@
 module Capybara
   module Assertions
     def self.included(base)
-      raise "Make sure to include Capybara::Minitest::Assertions after Capybara::DSL" unless base < Capybara::DSL
+      raise "Make sure to include Capybara::Assertions after Capybara::DSL" unless base < Capybara::DSL
     end
 
     def assert_text(*args)


### PR DESCRIPTION
Thanks for this gem!

The exception still references the old (?) constant `Capybara::Minitest::Assertions`. I have no idea what I'm doing.