### PR TITLE
Do an assertion with assert_selector call

### DIFF
--- a/lib/capybara/assertions.rb
+++ b/lib/capybara/assertions.rb
@@ -20,7 +20,7 @@ module Capybara
 
     def assert_selector(*args)
       node, *args = prepare_args(args)
-      node.assert_selector(*args)
+      assert node.assert_selector(*args)
     rescue Capybara::ExpectationNotMet => e
       assert false, e.message
     end


### PR DESCRIPTION
Without that assertion, suite runs good, and it tells me when the selector is and isn't present, it works fine. 

But at the end of the suite, the assertions count displayed by minitest don't reflect the real number of assertions. I added the assertion to display the correct number.