### PR TITLE
Fix missing failure text in Capybara 2.9+

### DIFF
--- a/lib/capybara/assertions.rb
+++ b/lib/capybara/assertions.rb
@@ -38,7 +38,7 @@ module Capybara
       ruby << <<-RUBY
         def assert_#{assertion}(*args)
           node, *args = prepare_args(args)
-          assert node.has_#{assertion}?(*args), message { Capybara::Helpers.failure_message(*args) }
+          assert node.has_#{assertion}?(*args), message { CapybaraFailureHelpers.failure_message(*args) }
         end
       RUBY
     end
@@ -46,7 +46,7 @@ module Capybara
       ruby << <<-RUBY
         def refute_#{refutation}(*args)
           node, *args = prepare_args(args)
-          assert node.has_no_#{refutation}?(*args), message { Capybara::Helpers.failure_message(*args) }
+          assert node.has_no_#{refutation}?(*args), message { CapybaraFailureHelpers.negative_failure_message(*args) }
         end
         alias_method :assert_no_#{refutation}, :refute_#{refutation}
       RUBY
@@ -288,6 +288,38 @@ module Capybara
         args
       else
         [page, *args]
+      end
+    end
+
+    module CapybaraFailureHelpers
+      def self.failure_message(description, options={})
+        String.new("expected to find #{description}") << count_message(options)
+      end
+
+      def self.negative_failure_message(description, options={})
+        String.new("expected not to find #{description}") << count_message(options)
+      end
+
+      def self.declension(singular, plural, count)
+        if count == 1
+          singular
+        else
+          plural
+        end
+      end
+
+      def self.count_message(options)
+        message = String.new()
+        if options[:count]
+          message << " #{options[:count]} #{declension('time', 'times', options[:count])}"
+        elsif options[:between]
+          message << " between #{options[:between].first} and #{options[:between].last} times"
+        elsif options[:maximum]
+          message << " at most #{options[:maximum]} #{declension('time', 'times', options[:maximum])}"
+        elsif options[:minimum]
+          message << " at least #{options[:minimum]} #{declension('time', 'times', options[:minimum])}"
+        end
+        message
       end
     end
   end

--- a/test/minitest/capybara_test.rb
+++ b/test/minitest/capybara_test.rb
@@ -35,12 +35,14 @@ class AppTest < Minitest::Capybara::Spec
 
   it "supports assert_link" do
     assert_link 'bar'
-    proc { assert_link("BAD") }.must_raise Minitest::Assertion
+    e = proc { assert_link("BAD") }.must_raise Minitest::Assertion
+    e.message.must_equal "expected to find BAD."
   end
 
   it "supports refute_link" do
     refute_link 'BAD'
-    proc { refute_link("bar") }.must_raise Minitest::Assertion
+    e = proc { refute_link("bar") }.must_raise Minitest::Assertion
+    e.message.must_equal "expected not to find bar."
   end
 
   # expectations


### PR DESCRIPTION
If minitest-capybara is used with Capybara 2.9+ then failures for certain assertions (like assert_link), will throw this error, rather than reporting the failure:

```
NoMethodError: undefined method `failure_message' for Capybara::Helpers:Module
```

The reason is because the `Capybara::Helpers.failure_message` method was refactored and disappeared in 2.9: https://github.com/teamcapybara/capybara/pull/1748

As noted in the pull request, `Capybara::Helpers` module is technically marked private, so this fixes it by bringing the necessary methods into minitest-capybara's code base.

I believe this should also solve a potential issue with some of the `refute_*` helpers returning the incorrect failure message (back when this was working with Capybara < 2.9). Since `failure_message` was being called for both assertions and refutations, the message was presumably the same. This updates things to use a separate `negative_failure_message` for the refutations (so `refute_link` would report "expected not to find..." instead of "expected to find...").