### PR TITLE
Update rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.1
-- 2.2
-- 2.3.0
+- 2.1.8
+- 2.2.6
+- 2.3.3
+- 2.4.0
 
 sudo: false
 script: RUBYOPT="-w $RUBYOPT" bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in minitest-matchers-capybara.gemspec
 gemspec
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
+  gem "rack", "< 2.0"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ gemspec
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
   gem "rack", "< 2.0"
 end
+
+# DO NOT RELEASE WITH THIS LINE STILL HERE.
+gem "capybara", "~> 2.8.0"


### PR DESCRIPTION
Update to use the latest ruby versions. Fix an issue with some older rubies being incompatible with current rack. Pin Capybara until the failure warnings are fixed by #17.