### PR TITLE
Loosen hard capybara dependency

### DIFF
--- a/minitest-capybara.gemspec
+++ b/minitest-capybara.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "capybara", "~> 2.2"
+  s.add_dependency "capybara"
 
   s.add_runtime_dependency "rake"
   s.add_runtime_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Fixes #20, which reports the gem is compatible with capybara@3.x, and all these APIs are stable enough now that I doubt it's likely to break much in the future.

More broadly, I'm not sure how helpful it is to have a hard dep on the gem being extended by this helper, but that would be a breaking change for anyone (incidentally) relying on this gem to date to get Capybara installed at all.